### PR TITLE
Fixed typo in sql query to fix merging vat numbers

### DIFF
--- a/merge_duplicate_contacts/wizard/merge_contact.py
+++ b/merge_duplicate_contacts/wizard/merge_contact.py
@@ -203,12 +203,18 @@ class MergePartnerAutomatic(models.TransientModel):
                 group_by_querries.append("parent_id")
 
             if field == "domain_email":
-                where_querries.append("substring(email from '@(.*)$') not in %s" % commercial_email_domains)
+                where_querries.append(
+                    "substring(email from '@(.*)$') not in %s"
+                    % commercial_email_domains
+                )
 
         # Construct the correct final querry here
-        if where_querries: final_querry += (" WHERE " + " AND ".join(where_querries) )
-        if group_by_querries: final_querry += (" GROUP BY " + ", ".join(group_by_querries))
-        if group_by_querries: final_querry += (" HAVING COUNT(*) > 1")
+        if where_querries:
+            final_querry += " WHERE " + " AND ".join(where_querries)
+        if group_by_querries:
+            final_querry += " GROUP BY " + ", ".join(group_by_querries)
+        if group_by_querries:
+            final_querry += " HAVING COUNT(*) > 1"
 
         return final_querry
 

--- a/merge_duplicate_contacts/wizard/merge_contact.py
+++ b/merge_duplicate_contacts/wizard/merge_contact.py
@@ -213,7 +213,6 @@ class MergePartnerAutomatic(models.TransientModel):
             final_querry += " WHERE " + " AND ".join(where_querries)
         if group_by_querries:
             final_querry += " GROUP BY " + ", ".join(group_by_querries)
-        if group_by_querries:
             final_querry += " HAVING COUNT(*) > 1"
 
         return final_querry

--- a/merge_duplicate_contacts/wizard/merge_partner_manual.py
+++ b/merge_duplicate_contacts/wizard/merge_partner_manual.py
@@ -527,9 +527,9 @@ class MergePartnerManualCheck(models.TransientModel):
                 if this.vat_1:
                     self._cr.execute(
                         """
-                        "UPDATE res_partner SET vat IN %s WHERE id IN %s"
-                    """,
-                        (tuple(this.vat_1), tuple(this.dst_partner_id.id)),
+                        UPDATE res_partner SET vat = %s WHERE id = %s
+                        """,
+                        (this.vat_1, this.dst_partner_id.id),
                     )
         else:
             this.dst_partner_id = this.partner_ids and this.partner_ids[1].id or False
@@ -557,9 +557,9 @@ class MergePartnerManualCheck(models.TransientModel):
                 if this.vat_2:
                     self._cr.execute(
                         """
-                        UPDATE res_partner SET vat IN %s WHERE id IN %s
+                        UPDATE res_partner SET vat = %s WHERE id = %s
                         """,
-                        (tuple(this.vat_2), tuple(this.dst_partner_id.id)),
+                        (this.vat_2, this.dst_partner_id.id),
                     )
 
         partner_ids = set(map(int, this.partner_ids))  # [:2]


### PR DESCRIPTION
Changed `SET vat IN` to `SET vat =` and removed incorrect `"` at beginning and end of query.
Also added missing `,` in tuples.